### PR TITLE
Diareses for German Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Before copying files to your keyboard, please [read this](windows.md) if you're 
 - [Tarmak](colemak/t_qwerty.txt)
 
 # Macros
+
+## Diareses (Umlauts) on German Windows
+- [Map LCTRL+A/O/U/S > Ä/Ö/Ü/ß](qwerty/w_qwerty.txt)
+
 ## General
 - [Map CAPS Lock > Backspace](productivity/general/caps-backspace.txt)
 

--- a/qwerty/w_qwerty.txt
+++ b/qwerty/w_qwerty.txt
@@ -1,0 +1,23 @@
+* =====  Windows Diareses macros =====
+*
+* Copyright 2017 by Markus Mayer.
+* Licensed under the MIT License.
+* See LICENSE file in the project root for full license information.
+*
+* Check https://superuser.com/a/604887/53942 to prevent clashes
+* with the language selector when pressing CTRL+SHIFT.
+
+* ae
+{lctrl}{a}>{speed9}{-lalt}{kp1}{kp3}{kp2}{+lalt}
+{lctrl}{lshift}{a}>{speed9}{-lalt}{kp1}{kp4}{kp2}{+lalt}
+
+* oe
+{lctrl}{o}>{speed9}{-lalt}{kp1}{kp4}{kp8}{+lalt}
+{lctrl}{lshift}{o}>{speed9}{-lalt}{kp1}{kp5}{kp3}{+lalt}
+
+* ue
+{lctrl}{u}>{speed9}{-lalt}{kp1}{kp2}{kp9}{+lalt}
+{lctrl}{lshift}{u}>{speed9}{-lalt}{kp1}{kp5}{kp4}{+lalt}
+
+* sz
+{lctrl}{s}>{speed9}{-lalt}{kp2}{kp2}{kp5}{+lalt}


### PR DESCRIPTION
This adds diaresis (Umlaut) support for German Windows users who don't want to use the US-International layout (like me).

| Combo | Result
| ----- | ---
| `LCTRL`+`A` | `ä`
| `LCTRL`+`O` | `ö`
| `LCTRL`+`U` | `ü`
| `LCTRL`+`S` | `ß`
| `LCTRL`+`SHIFT`+`A` | `Ä`
| `LCTRL`+`SHIFT`+`O` | `Ö`
| `LCTRL`+`SHIFT`+`U` | `Ü`

One problem is that Windows maps `CTRL`+`SHIFT` to the language switcher, which can lead to confusion when more than one layout is installed. A way to change this is described [here](https://superuser.com/a/604887/53942). This is documented in the layout file as well.