### PR TITLE
„99-66“ quotation marks

### DIFF
--- a/qwerty/w_qwerty.txt
+++ b/qwerty/w_qwerty.txt
@@ -21,3 +21,7 @@
 
 * sz
 {lctrl}{s}>{speed9}{-lalt}{kp2}{kp2}{kp5}{+lalt}
+
+* fancy quotes
+{lctrl}{'}>{speed9}{-lalt}{kp0}{kp1}{kp3}{kp2}{+lalt}
+{lctrl}{lshift}{'}>{speed9}{-lalt}{kp0}{kp1}{kp4}{kp7}{+lalt}


### PR DESCRIPTION
A tiny addition to the diacritics macros, this adds the correct "99-66" quotation marks („“) for the German language.

| Combo | Result
| ----- | ---
| `LCTRL`+`'` | `„` (99)
| `LCTRL`+`SHIFT`+`'` | `“` (66)